### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ whether one is contained within the other.
 The best way to install this module is to use `cpan` or `cpanm`:
 
 ```
-cpanm install Set::Tiny
+cpanm Set::Tiny
+```
+
+or 
+
+```
+cpan -i Set::Tiny
 ```
 
 Since `Set::Tiny` is available at [CPAN](https://metacpan.org/).


### PR DESCRIPTION
The instructions for installing with `cpanm` are incorrect.  

Since `cpan` is also mentioned, I add added the command to install using that too.